### PR TITLE
Fix stream argument in console backend

### DIFF
--- a/flask_email/backends/console.py
+++ b/flask_email/backends/console.py
@@ -11,7 +11,7 @@ class Mail(BaseMail):
     :param \*\*kwargs: Options to be passed to :meth:`init_app`
     """
 
-    def init_app(self, app, stream=None, **kwargs):
+    def init_app(self, app, **kwargs):
         """
         :arg app: Flask application instance
         :keyword stream: Stream to write to


### PR DESCRIPTION
Addresses problem with `filebased` backend that writes to `sys.stdout` instead of created file.
